### PR TITLE
feat: add tls-upstream Envoy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ I've been running these configurations on MacOS Catalina. You'll want to ensure 
 * [shadow](shadow)
 * [sni-match](sni-match)
 * [tls-terminate](tls-terminate)
+* [tls-upstream](tls-upstream)

--- a/tls-upstream/Makefile
+++ b/tls-upstream/Makefile
@@ -1,0 +1,53 @@
+.PHONY: build-all build test tag_latest_all release ssh
+
+APP="tls-upstream"
+
+help:
+	@echo "General Commands"
+	@echo "    help:  Show help"
+	@echo ""
+	@echo "Copy certs:"
+	@echo "    copy-certs"
+	@echo ""
+	@echo "Verify Envoy config locally:"
+	@echo "    verify-config"
+	@echo ""
+	@echo "Run Envoy:"
+	@echo "    run"
+	@echo ""
+	@echo "Stop Envoy:"
+	@echo "    stop"
+	@echo ""
+	@echo "Rebuild (stop + start) Envoy:"
+	@echo "    rebuild"
+	@echo ""
+	@echo "Validate that connection to Flask app succeeds:"
+	@echo "    test"
+	@echo ""
+
+copy-certs:
+	@mkdir -p certs
+	@cp ../certs/app.* certs/
+
+verify-config:
+	@docker run --rm -v "`pwd`/envoy/proxy-$(APP).yaml":/etc/proxy-$(APP).yaml \
+	                 -v "`pwd`/certs/app.key":/etc/app.key \
+					 -v "`pwd`/certs/app.crt":/etc/app.crt \
+					 envoyproxy/envoy-alpine:latest envoy -c /etc/proxy-$(APP).yaml --mode validate 
+
+build:
+	@docker-compose -p envoy-$(APP) build
+
+run:
+	@docker-compose -p envoy-$(APP) up -d --force-recreate
+
+stop:
+	@docker-compose -p envoy-$(APP) down
+
+rebuild: stop run
+
+test:
+	@echo "HINT: Make sure you set app.local to 127.0.0.1 in your hosts file!"
+	@echo ""
+	@echo "Running command: curl --cacert ../certs/CA.crt  https://app.local"
+	@curl --cacert ../certs/CA.crt  https://app.local

--- a/tls-upstream/README.md
+++ b/tls-upstream/README.md
@@ -1,0 +1,73 @@
+# Envoy TLS
+Front-end proxy Envoy configuration configures end-to-end TLS connection to the upstream cluster.
+
+## Implementation
+This configuration creates an Envoy container that listens on port 443 that will direct traffic via HTTPS to a Flask container that is only accessible from Envoy. Since Envoy is terminating the TLS connection, this configuration requires a server private and public certificate. The certificates generated from this repo will create a cert with two domain names: `app.local` and `app.alternate`. These same certificates will be added to the Flask container which is running `nginx`.
+
+## Usage
+I've added a `Makefile` to simplify the execution of commands. `docker-compose` is used to manage the underlying containers.
+
+### Generating Certs
+If you haven't already, you'll need to generate the certificates needed for this configuration. Go to the root of the repo and run these commands:
+
+```
+make create-ca-certs
+make create-server-certs
+```
+
+### Copy Certs
+Once the certs have been generated for the repo, you'll need to copy them into this configuration. Be sure that you are back in the `sni-match` folder and run the following command:
+
+```
+make copy-certs
+```
+
+### Build App Container
+Since we need to override the default configuration for the app container to add TLS support, we need to build a new image first:
+```
+make build
+```
+
+### Launch Containers
+```
+make run
+```
+
+### Stop Containers
+```
+make stop
+```
+
+### Test Connection
+
+```
+make test
+```
+
+```
+HINT: Make sure you set app.local to 127.0.0.1 in your hosts file!
+
+Running command: curl --cacert ../certs/CA.crt  https://app.local
+Hello Envoy world!
+```
+
+## Key Configuration
+The main difference between this configuration and `tls-upstream` is adding a similar `transport-sockets` configuration to the upstream cluster.
+
+__envoy/proxy-tls-upstream.yaml__
+
+Things to note:
+* `port_value`: Make sure to set this to `443` or whatever port that your upstream endpoint is listening on for TLS.
+* `@type`: At the end, notice that the value is set to `UpstreamTlsContext` which is different from the listener config which has `DownstreamTlsContext`.
+
+```yaml
+clusters:
+- name: app
+  connect_timeout: 5s
+  type: LOGICAL_DNS
+  hosts: [{ socket_address: { address: app, port_value: 443 }}]
+  transport_socket:
+    name: envoy.transport_sockets.tls
+    typed_config:
+      "@type": type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext
+```

--- a/tls-upstream/docker-compose.yml
+++ b/tls-upstream/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.7'
+services:
+  app:
+    build:
+      context: ./flask-tls
+      dockerfile: Dockerfile
+    volumes:
+      - ./certs/app.crt:/etc/ssl/app.crt
+      - ./certs/app.key:/etc/ssl/app.key
+  envoy:
+    build:
+      context: ./envoy
+      dockerfile: Dockerfile
+    volumes:
+      - ./envoy/proxy-tls.yaml:/etc/proxy-tls.yaml
+      - ./certs/app.crt:/etc/app.crt
+      - ./certs/app.key:/etc/app.key
+    expose:
+      - "443"
+      - "8881"
+    ports: 
+      - 443:443
+      - 8881:8881

--- a/tls-upstream/envoy/Dockerfile
+++ b/tls-upstream/envoy/Dockerfile
@@ -1,0 +1,5 @@
+FROM envoyproxy/envoy-alpine:latest
+
+RUN apk --no-cache add curl
+COPY proxy-tls-upstream.yaml /etc/proxy-tls-upstream.yaml
+CMD /usr/local/bin/envoy -c /etc/proxy-tls-upstream.yaml --service-cluster proxy-tls-upstream

--- a/tls-upstream/envoy/proxy-tls-upstream.yaml
+++ b/tls-upstream/envoy/proxy-tls-upstream.yaml
@@ -1,0 +1,58 @@
+admin:
+    access_log_path: "/dev/stdout"
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 9901
+    
+static_resources:
+  listeners:
+  - address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 443
+    filter_chains:
+    - transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.api.v2.auth.DownstreamTlsContext
+          common_tls_context:
+            tls_certificates:
+            - certificate_chain: { filename: "/etc/app.crt" }
+              private_key: { filename: "/etc/app.key" }
+            alpn_protocols: [ "h2,http/1.1" ]
+      filters:
+      - name: envoy.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
+          use_remote_address: true
+          skip_xff_append: false
+          stat_prefix: ingress_http
+          access_log:
+            - name: envoy.file_access_log
+              config:
+                path: "/dev/stdout"
+          xff_num_trusted_hops: 2
+          server_name: "envoy-tls-upstream"
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: app
+          http_filters:
+            - name: envoy.router
+  clusters:
+  - name: app
+    connect_timeout: 5s
+    type: LOGICAL_DNS
+    hosts: [{ socket_address: { address: app, port_value: 443 }}]
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext
+  

--- a/tls-upstream/flask-tls/Dockerfile
+++ b/tls-upstream/flask-tls/Dockerfile
@@ -1,0 +1,4 @@
+FROM thebernank/flask:latest
+
+## Add TLS config
+COPY nginx_tls.conf /etc/nginx/conf.d/tls.conf

--- a/tls-upstream/flask-tls/nginx_tls.conf
+++ b/tls-upstream/flask-tls/nginx_tls.conf
@@ -1,0 +1,18 @@
+server {
+    listen              443 ssl;
+    server_name         app.local;
+    ssl_certificate     /etc/ssl/app.crt;
+    ssl_certificate_key /etc/ssl/app.key;
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+    location / {
+        try_files $uri @app;
+    }
+    location @app {
+        include uwsgi_params;
+        uwsgi_pass unix:///tmp/uwsgi.sock;
+    }
+    location /static {
+        alias /var/www/flask/static;
+    }
+}


### PR DESCRIPTION
This is similar to the `tls-terminate` configuration except that traffic sent to the upstream cluster is TLS rather than plain HTTP. As a result it is required to add TLS config to the app containers `nginx` configuration.